### PR TITLE
Made it possible to override scss variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,15 @@ $('#tabs-inside-here').scrollingTabs('destroy');
 If you were wrapping markup, the markup will be restored; if your tabs were data-driven, the tabs will be destroyed along with the plugin.
 
 
+Custom SCSS
+-----------
+Customise the SCSS by including `jquery.scrolling-tabs.scss` and overriding the following variables:
+* `$scrtabs-tabs-height` - The height of the tabs.
+* `$scrtabs-border-color` - The tabs border color.
+* `$scrtabs-foreground-color` - The text color.
+* `$scrtabs-background-color-hover` - The background color of the tabs when hovered over.
+
+
 License
 -------
 MIT License.

--- a/jquery.scrolling-tabs.scss
+++ b/jquery.scrolling-tabs.scss
@@ -5,17 +5,25 @@
  * @author Mike Jacobson <michaeljjacobson1@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
-$tabs-height: 42px;
-$border-bootstrap-lt-gray: 1px solid rgb(221, 221, 221);
-$color-bootstrap-blue: rgb(66, 139, 202);
-$background-color-bootstrap-gray-hover: rgb(238, 238, 238);
+
+// Tabs height
+$scrtabs-tabs-height: 42px !default;
+
+// Border color (bootstrap lt gray)
+$scrtabs-border-color: 1px solid rgb(221, 221, 221) !default;
+
+// Foreground color (bootstrap blue)
+$scrtabs-foreground-color: rgb(66, 139, 202) !default;
+
+// Background color on hover (bootstrap gray)
+$scrtabs-background-color-hover: rgb(238, 238, 238) !default;
 
 .scrtabs-tab-container * {
   box-sizing: border-box;
 }
 
 .scrtabs-tab-container {
-  height: $tabs-height;
+  height: $scrtabs-tabs-height;
   .tab-content {
     clear: left;
   }
@@ -23,7 +31,7 @@ $background-color-bootstrap-gray-hover: rgb(238, 238, 238);
 
 .scrtabs-tabs-fixed-container {
   float: left;
-  height: $tabs-height;
+  height: $scrtabs-tabs-height;
   overflow: hidden;
   width: 100%;
 }
@@ -36,20 +44,20 @@ $background-color-bootstrap-gray-hover: rgb(238, 238, 238);
 }
 
 .scrtabs-tab-scroll-arrow {
-  border: $border-bootstrap-lt-gray;
+  border: $scrtabs-border-color;
   border-top: none;
-  color: $color-bootstrap-blue;
+  color: $scrtabs-background-color-hover;
   cursor: pointer;
   display: none;
   float: left;
   font-size: 12px;
-  height: $tabs-height;
+  height: $scrtabs-tabs-height;
   margin-bottom: -1px;
   padding-left: 2px;
   padding-top: 13px;
   width: 20px;
   &:hover {
-    background-color: $background-color-bootstrap-gray-hover;
+    background-color: $scrtabs-background-color-hover;
   }
 }
 


### PR DESCRIPTION
We import your .scss file as part of our stylesheet compilation.

The main change is adding [!default](http://www.sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_) to the existing scss variables to make it possible to override the values when importing your file.

I have generalised the variable names as `$color-bootstrap-blue` might not make so much sense if I change the color to be green. I have also added a `scrtabs-` prefix to prevent conflicts with other libraries when importing your file.

I have also updated the documentation to explain how others can use the variables.